### PR TITLE
The top level `pub` command is deprecated. Use `dart pub` instead.

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -27,7 +27,7 @@ jobs:
       with:
         sdk: beta
     - name: install dependencies
-      run: pub get
+      run: dart pub get
     - name: analyzer
       run: dart analyze --fatal-infos --fatal-warnings .
 
@@ -39,7 +39,7 @@ jobs:
       with:
         sdk: beta
     - name: install dependencies
-      run: pub get
+      run: dart pub get
     - name: run test
       run: pub run test . --coverage=coverage
     - name: coverage

--- a/.github/workflows/publish_artifacts_gcc.yaml
+++ b/.github/workflows/publish_artifacts_gcc.yaml
@@ -40,7 +40,7 @@ jobs:
           sdk: beta
           architecture: x64
       - name: install dependencies
-        run: pub get
+        run: dart pub get
 
       - name: build edax-reversi
         env:

--- a/.github/workflows/publish_artifacts_icc.yaml
+++ b/.github/workflows/publish_artifacts_icc.yaml
@@ -75,7 +75,7 @@ jobs:
           sdk: beta
           architecture: x64
       - name: install dependencies
-        run: pub get
+        run: dart pub get
 
       # setup Intel Compiler icc
       - uses: actions/checkout@v2

--- a/.github/workflows/publish_assets_gcc.yaml
+++ b/.github/workflows/publish_assets_gcc.yaml
@@ -36,7 +36,7 @@ jobs:
           sdk: beta
           architecture: x64
       - name: install dependencies
-        run: pub get
+        run: dart pub get
 
       - name: build edax-reversi
         env:

--- a/.github/workflows/publish_assets_icc.yaml
+++ b/.github/workflows/publish_assets_icc.yaml
@@ -71,7 +71,7 @@ jobs:
           sdk: beta
           architecture: x64
       - name: install dependencies
-        run: pub get
+        run: dart pub get
 
       # setup Intel Compiler icc
       - uses: actions/checkout@v2


### PR DESCRIPTION
```console
$ pub get
The top level `pub` command is deprecated. Use `dart pub` instead.
Resolving dependencies...
Got dependencies!
```